### PR TITLE
Sanitize contact fields before submitting forms

### DIFF
--- a/App.js
+++ b/App.js
@@ -30,6 +30,7 @@ import api from './helpers/api';
 import storage from './helpers/storage';
 import widget from './helpers/widget';
 import banner from './helpers/banner';
+import { sanitizeCredentialIdentifier } from './helpers/userSanitizer';
 import RevenueCat from './helpers/revenueCat';
 import analytics from './helpers/analytics';
 import SnippetsScreen from './screens/SnippetsScreen';
@@ -149,6 +150,7 @@ export default Sentry.wrap(function App() {
     let user = null;
     let responseJson;
     try {
+      emailOrPhone = sanitizeCredentialIdentifier(emailOrPhone);
       const response = await api.login(emailOrPhone, password);
       if (!response?.ok) { throw new Error(`HTTP error with status ${response?.status}`); }
       responseJson = await response.json();

--- a/helpers/storage.js
+++ b/helpers/storage.js
@@ -6,15 +6,20 @@ import { featureAlertTypes } from '../constants/featureAlertTypes';
 import { snippetTypes } from '../constants/snippetTypes';
 import { moveSnippetOptions } from '../constants/moveSnippetOptions';
 import { snippetSources } from '../constants/snippetSources';
+import { sanitizeCredentialIdentifier } from './userSanitizer';
 
 const getCredentials = async () => {
   const item = await AsyncStorage.getItem(storageKeys.CREDENTIALS);
   const credentials = JSON.parse(item);
+  if (credentials?.emailOrPhone) {
+    credentials.emailOrPhone = sanitizeCredentialIdentifier(credentials.emailOrPhone);
+  }
   console.log(`storage.js -> getCredentials: ${credentials?.emailOrPhone ? `Got credentials for ${credentials.emailOrPhone}` : 'No credentials in storage'}`);
   return credentials;
 };
 
 const saveCredentials = async (emailOrPhone, password) => {
+  emailOrPhone = sanitizeCredentialIdentifier(emailOrPhone);
   console.log('storage.js -> saveCredentials: Saving credentials for ', emailOrPhone);
   const credentials = { emailOrPhone, password };
   if (validator.isValidCredentials(credentials)) {

--- a/helpers/userSanitizer.js
+++ b/helpers/userSanitizer.js
@@ -1,0 +1,20 @@
+const sanitizeField = (value, { toLowerCase } = {}) => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  const trimmed = `${value}`.trim();
+  return toLowerCase ? trimmed.toLowerCase() : trimmed;
+};
+
+export const sanitizeUserContactFields = (user = {}) => {
+  if (!user || typeof user !== 'object') {
+    return user;
+  }
+
+  return {
+    ...user,
+    email_address: sanitizeField(user.email_address, { toLowerCase: true }),
+    phone_number: sanitizeField(user.phone_number),
+  };
+};

--- a/helpers/userSanitizer.js
+++ b/helpers/userSanitizer.js
@@ -7,13 +7,28 @@ const sanitizeField = (value, { toLowerCase } = {}) => {
   return toLowerCase ? trimmed.toLowerCase() : trimmed;
 };
 
+const sanitizePhoneNumber = (value) => {
+  const trimmedValue = sanitizeField(value);
+  if (trimmedValue === null || trimmedValue === undefined || trimmedValue === '') {
+    return trimmedValue;
+  }
+
+  const hasLeadingPlus = trimmedValue.startsWith('+');
+  const digitsOnly = trimmedValue.replace(/\D/g, '');
+  if (!digitsOnly) {
+    return trimmedValue;
+  }
+
+  return hasLeadingPlus ? `+${digitsOnly}` : digitsOnly;
+};
+
 export const sanitizeCredentialIdentifier = (emailOrPhone) => {
   const trimmedValue = sanitizeField(emailOrPhone);
   if (trimmedValue === null || trimmedValue === undefined || trimmedValue === '') {
     return trimmedValue;
   }
 
-  return trimmedValue.includes('@') ? trimmedValue.toLowerCase() : trimmedValue;
+  return trimmedValue.includes('@') ? trimmedValue.toLowerCase() : sanitizePhoneNumber(trimmedValue);
 };
 
 export const sanitizeUserContactFields = (user = {}) => {
@@ -24,6 +39,6 @@ export const sanitizeUserContactFields = (user = {}) => {
   return {
     ...user,
     email_address: sanitizeField(user.email_address, { toLowerCase: true }),
-    phone_number: sanitizeField(user.phone_number),
+    phone_number: sanitizePhoneNumber(user.phone_number),
   };
 };

--- a/helpers/userSanitizer.js
+++ b/helpers/userSanitizer.js
@@ -7,6 +7,15 @@ const sanitizeField = (value, { toLowerCase } = {}) => {
   return toLowerCase ? trimmed.toLowerCase() : trimmed;
 };
 
+export const sanitizeCredentialIdentifier = (emailOrPhone) => {
+  const trimmedValue = sanitizeField(emailOrPhone);
+  if (trimmedValue === null || trimmedValue === undefined || trimmedValue === '') {
+    return trimmedValue;
+  }
+
+  return trimmedValue.includes('@') ? trimmedValue.toLowerCase() : trimmedValue;
+};
+
 export const sanitizeUserContactFields = (user = {}) => {
   if (!user || typeof user !== 'object') {
     return user;

--- a/screens/ForgotPasswordScreen.js
+++ b/screens/ForgotPasswordScreen.js
@@ -7,6 +7,7 @@ import banner from '../helpers/banner';
 import ActionButton from '../components/ActionButton';
 import api from '../helpers/api';
 import analytics from '../helpers/analytics';
+import { sanitizeCredentialIdentifier } from '../helpers/userSanitizer';
 const ForgotPasswordScreen = ({ navigation }) => {
   const { t } = useTranslation(['common', 'auth', 'errors']);
   const { themer } = useContext(ApplicationContext);
@@ -23,7 +24,9 @@ const ForgotPasswordScreen = ({ navigation }) => {
   const onSendPasswordResetEmailTapped = async () => {
     try {
       setIsLoading(true);
-      const response = await api.sendPasswordResetEmail(emailOrPhone);
+      const sanitizedEmailOrPhone = sanitizeCredentialIdentifier(emailOrPhone);
+      setEmailOrPhone(sanitizedEmailOrPhone);
+      const response = await api.sendPasswordResetEmail(sanitizedEmailOrPhone);
       if (!response?.ok) { throw new Error(`HTTP error with status ${response?.status}`); }
       let responseJson = await response.json();
       if (responseJson && responseJson.success) {

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -6,6 +6,7 @@ import { ApplicationContext } from '../ApplicationContext';
 import banner from '../helpers/banner';
 import analytics from '../helpers/analytics';
 import ActionButton from '../components/ActionButton';
+import { sanitizeCredentialIdentifier } from '../helpers/userSanitizer';
 
 const LoginScreen = ({ navigation }) => {
   const { t } = useTranslation(['common', 'auth', 'errors']);
@@ -23,7 +24,12 @@ const LoginScreen = ({ navigation }) => {
   const onLoginTapped = async () => {
     try {
       setIsLoading(true);
-      const responseJson = await loginWithCredentials(credentials?.emailOrPhone, credentials?.password);
+      const sanitizedCredentials = {
+        ...credentials,
+        emailOrPhone: sanitizeCredentialIdentifier(credentials?.emailOrPhone),
+      };
+      setCredentials(sanitizedCredentials);
+      const responseJson = await loginWithCredentials(sanitizedCredentials?.emailOrPhone, sanitizedCredentials?.password);
       if (responseJson && responseJson.success && responseJson.user) {
         await analytics.logEvent('login', { method: 'email' });
         console.log(`LoginScreen.js -> onLoginTapped: User logged in. Going back to Settings screen..`);

--- a/screens/RegisterScreen.js
+++ b/screens/RegisterScreen.js
@@ -8,6 +8,7 @@ import api from '../helpers/api';
 import banner from '../helpers/banner';
 import analytics from '../helpers/analytics';
 import ActionButton from '../components/ActionButton';
+import { sanitizeUserContactFields } from '../helpers/userSanitizer';
 
 const RegisterScreen = ({ navigation }) => {
   const { t } = useTranslation(['common', 'auth', 'errors']);
@@ -25,16 +26,18 @@ const RegisterScreen = ({ navigation }) => {
   const onRegisterTapped = async () => {
     try {
       setIsLoading(true);
-      if (user.password != user.password_confirm) {
+      const sanitizedUser = sanitizeUserContactFields(user);
+      setUser(sanitizedUser);
+      if (sanitizedUser.password != sanitizedUser.password_confirm) {
         throw new Error(t('auth:passwordMismatch'));
       }
-      const response = await api.register(user);
+      const response = await api.register(sanitizedUser);
       if (!response?.ok) { throw new Error(`HTTP error with status ${response?.status}`); }
       let responseJson = await response.json();
       if (responseJson && responseJson.success && responseJson.user) {
         await analytics.logEvent('signup', { user_id: responseJson.user.id });
-        console.log(`RegisterScreen.js -> onRegisterTapped: User registered with email address ${user.email_address}. Now logging user in..`);
-        responseJson = await loginWithCredentials(user.email_address, user.password);
+        console.log(`RegisterScreen.js -> onRegisterTapped: User registered with email address ${sanitizedUser.email_address}. Now logging user in..`);
+        responseJson = await loginWithCredentials(sanitizedUser.email_address, sanitizedUser.password);
         if (responseJson && responseJson.success && responseJson.user) {
           console.log(`RegisterScreen.js -> onRegisterTapped: User logged in. Going back to Settings screen..`);
           navigation.goBack();

--- a/screens/UserScreen.js
+++ b/screens/UserScreen.js
@@ -11,6 +11,7 @@ import api from '../helpers/api';
 import banner from '../helpers/banner';
 import analytics from '../helpers/analytics';
 import ActionButton from '../components/ActionButton';
+import { sanitizeUserContactFields } from '../helpers/userSanitizer';
 
 const UserScreen = ({ navigation }) => {
   const { t } = useTranslation(['common', 'auth', 'errors']);
@@ -41,16 +42,18 @@ const UserScreen = ({ navigation }) => {
   const onSaveTapped = async () => {
     try {
       setIsLoading(true);
-      if (editedUser.password != editedUser.password_confirm) {
+      const sanitizedUser = sanitizeUserContactFields(editedUser);
+      setEditedUser(sanitizedUser);
+      if (sanitizedUser.password != sanitizedUser.password_confirm) {
         throw new Error('Password confirmation must match the password entered.');
       }
-      const response = await api.saveUser(editedUser, await storage.getAuthorizationToken());
+      const response = await api.saveUser(sanitizedUser, await storage.getAuthorizationToken());
       if (!response?.ok) { throw new Error(`HTTP error with status ${response?.status}`); }
       let responseJson = await response.json();
       if (responseJson && responseJson.success && responseJson.user) {
-        await analytics.logEvent('user_edited', { properties: Object.keys(editedUser).filter(key => editedUser[key] !== user[key]).length });
+        await analytics.logEvent('user_edited', { properties: Object.keys(sanitizedUser).filter(key => sanitizedUser[key] !== user[key]).length });
         console.log(`UserScreen.js -> onSaveTapped: User saved. Now logging user in again..`);
-        responseJson = await loginWithCredentials(editedUser.email_address, editedUser.password);
+        responseJson = await loginWithCredentials(sanitizedUser.email_address, sanitizedUser.password);
         if (responseJson && responseJson.success && responseJson.user) {
           console.log(`UserScreen.js -> onSaveTapped: User logged in. Going back to Settings screen..`);
           navigation.goBack();


### PR DESCRIPTION
## Summary
- add a helper that trims user email/phone values and forces emails to lowercase before we send them to the API
- apply that sanitizer inside the register and account edit flows so we never submit values with stray whitespace or uppercase letters
- ensure follow-up login + analytics calls use the sanitized values so the same casing reaches the API everywhere

## Testing
- npm test -- --watchAll=false *(fails because jest can't parse ESM modules from @react-navigation/native in this repo's current config)*
